### PR TITLE
Preserve cache-control when using this gem in rails 5

### DIFF
--- a/lib/action_dispatch/routing/static_responder.rb
+++ b/lib/action_dispatch/routing/static_responder.rb
@@ -51,17 +51,19 @@ require 'action_dispatch/middleware/static'
 
 module ActionDispatch
   module Routing
+
     if Gem::Version.new(Rails.version) >= Gem::Version.new('4.2')
       class StaticResponder < Endpoint; end
     else
       class StaticResponder; end
     end
 
-    if Gem::Version.new(Rails.version) >= Gem::Version.new('5.0')
+    if Gem::Version.new(Rails.version) < Gem::Version.new('5.0')
       class StaticResponder
         def file_handler
           @file_handler ||= ::ActionDispatch::FileHandler.new(
-            Rails.configuration.paths["public"].first
+            Rails.configuration.paths["public"].first,
+            Rails.configuration.static_cache_control
           )
         end
       end
@@ -70,7 +72,7 @@ module ActionDispatch
         def file_handler
           @file_handler ||= ::ActionDispatch::FileHandler.new(
             Rails.configuration.paths["public"].first,
-            Rails.configuration.static_cache_control
+            headers: Rails.configuration.public_file_server.headers
           )
         end
       end

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -44,7 +44,7 @@ Rails.application.configure do
 
     config.public_file_server.enabled = false
     config.public_file_server.headers = {
-      'Cache-Control' => "public, max-age=#{1.hour.seconds.to_i}"
+      'Cache-Control' => "my-cache-control"
     }
 
   else
@@ -63,7 +63,7 @@ Rails.application.configure do
 
     # Configure static asset server for tests with Cache-Control for performance.
     config.serve_static_assets  = false
-    config.static_cache_control = 'public, max-age=3600'
+    config.static_cache_control = 'my-cache-control'
 
     # Show full error reports and disable caching.
     config.consider_all_requests_local       = true

--- a/spec/integration/routing_spec.rb
+++ b/spec/integration/routing_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'Integration Test', type: :request do
     get '/lucu.txt'
     expect(response).to have_http_status(:ok)
     expect(response.body.strip).to eq('hi!')
+    expect(response.headers['Cache-Control']).to eq('my-cache-control')
   end
 
   it 'cant response via non-defined static routes' do


### PR DESCRIPTION
In Rails 5 this gem doesn't pass down properly the cache-control header configured to serve assets which prevents us from having short-lived cache in development for assets served using `static()` at router level. This works properly using rails 4.x as it's a required param properly passed by that gem.

Rails 5 has changed the way to pass down headers to ActionDispatch::FileHandler by moving the responsibility to the caller. See https://github.com/rails/rails/blob/4-2-stable/actionpack/lib/action_dispatch/middleware/static.rb#L19 vs https://github.com/rails/rails/blob/5-0-stable/actionpack/lib/action_dispatch/middleware/static.rb#L18 which passes down headers directly to `Rack::File`.

This PR fixes the behavior to be consistent by always honoring `Rails.configuration.static_cache_control` or `Rails.configuration.public_file_server.headers` whether you use 4.x or 5+.